### PR TITLE
Fixed usage in directories with spaces in the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ If either environment variable is missing, basic authentication is removed.
 
 Basic usage:
 
-	docker run -d --name webdav -p 80:80 -v $PWD:/var/www visity/webdav
+	docker run -d --name webdav -p 80:80 -v "$PWD":/var/www visity/webdav
 	


### PR DESCRIPTION
If $PWD returns a directory name with spaces parts of that name are considered as arguments for the `docker` command if it is not wrapped with quotes.
