### PR TITLE
Fixes creation of htpassword.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@
 FROM      debian:jessie
 
 RUN       apt-get update && \
-          apt-get install -y nginx nginx-extras && \
+          apt-get install -y --force-yes nginx nginx-extras && \
           rm -rf /var/lib/apt/lists/*
     
 COPY      set_htpasswd.sh /set_htpasswd.sh
+COPY      crypt.pl /crypt.pl
 COPY      webdav-site.conf /etc/nginx/sites-enabled/
 RUN       rm /etc/nginx/sites-enabled/default
 # Overwrite mimetypes to add rss format.

--- a/crypt.pl
+++ b/crypt.pl
@@ -1,0 +1,14 @@
+#!/usr/bin/perl
+use strict;
+
+chomp(my $filename=$ARGV[0]);
+chomp(my $username=$ARGV[1]);
+chomp(my $password=$ARGV[2]);
+
+if (!$filename || !$username || !$password) {
+  print "USAGE: ./crypt.pl filename username password\n\n";
+} else {
+  open my $fh, ">>", $filename or die $!;
+  print $fh $username . ":" . crypt($password, $username) . "\n";
+  close $fh or die $!;
+}

--- a/set_htpasswd.sh
+++ b/set_htpasswd.sh
@@ -2,7 +2,7 @@
 
 if [[ -n "$WEBDAV_USERNAME" ]] && [[ -n "$WEBDAV_PASSWORD" ]]
 then
-	htpasswd -c /etc/nginx/webdavpasswd $WEBDAV_USERNAME $WEBDAV_PASSWORD
+	/crypt.pl /etc/nginx/webdavpasswd $WEBDAV_USERNAME $WEBDAV_PASSWORD
 else
 	echo "No htpasswd config done"
 	sed -i 's%auth_basic "Restricted";% %g' /etc/nginx/sites-enabled/webdav-site.conf


### PR DESCRIPTION
The original code used htpasswd which wasn't in the container so it wouldn't work with password. This adds the crypt.pl script which creates the necessary file to add user/password authentication to webdav.
